### PR TITLE
Environment fix to address the broken build

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,4 @@ dependencies:
   - jupyter-book
   - jupyterlab
   - sphinx-pythia-theme==2022.3.29
+  - markdown-it-py<2

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,7 @@ name: sea-iss-submission
 channels:
   - conda-forge
 dependencies:
+  - python<3.12
   - jupyter-book
   - jupyterlab
   - sphinx-pythia-theme==2022.3.29
-  - markdown-it-py<2
-  - lxml[html_clean]

--- a/environment.yml
+++ b/environment.yml
@@ -2,8 +2,8 @@ name: sea-iss-submission
 channels:
   - conda-forge
 dependencies:
-  - python<3.12
   - jupyter-book
   - jupyterlab
   - sphinx-pythia-theme==2022.3.29
-  - lxml<5.2
+  - pip:
+    - lxml[html_clean]

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - jupyter-book
   - jupyterlab
   - sphinx-pythia-theme==2022.3.29
+  - lxml[html_clean]

--- a/environment.yml
+++ b/environment.yml
@@ -6,3 +6,4 @@ dependencies:
   - jupyterlab
   - sphinx-pythia-theme==2022.3.29
   - markdown-it-py<2
+  - lxml[html_clean]

--- a/environment.yml
+++ b/environment.yml
@@ -6,4 +6,4 @@ dependencies:
   - jupyter-book
   - jupyterlab
   - sphinx-pythia-theme==2022.3.29
-  - lxml[html_clean]
+  - lxml<5.2


### PR DESCRIPTION
Looks like the new package that was split off and now is needed is only on PyPI and not conda-forge (that I can tell) so that's why it was still breaking.

We should either squash merge this or I can clean up the history on my end first if you prefer.