### PR TITLE
Additional Improvements for ISS-2025

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/UCAR-SEA/SEA-ISS-Template/main?labpath=notebooks)
 [![DOI](https://zenodo.org/badge/739166874.svg?style=flat-square)](https://zenodo.org/doi/10.5281/zenodo.10499040)
 
-This repository contains a template for submitting your paper to the [2025 Software Engineering Assembly Conference](https://sea.ucar.edu/event/sea-2025).
+This repository contains a template for submitting your paper to the [2025 Software Engineering Assembly Conference](https://sea.ucar.edu/iss/2025/).
 
 ## How to Use This Template 🛠️
 

--- a/submission-guidelines.md
+++ b/submission-guidelines.md
@@ -9,14 +9,18 @@
 1. **Create a New Repository Using this Template**: Click on the "Use this template" button to create a new repository with the files from this template. 
 ![Use this template](assets/use-this-template.png)
 
+```{note}
+   If you want to learn more about Git and GitHub, you can check out the following tutorials: 
+   - [Git Handbook](https://guides.github.com/introduction/git-handbook/)
+   - [Version Control with Git](https://swcarpentry.github.io/git-novice/)
+   - [Git Branching Guide](https://learngitbranching.js.org/)
+```
+
 2. **Name your Repository**: Name your repository using the following naming convention: `SEA-ISS-2025-<paper-title>`. For example, if your paper title is "My Awesome Paper", your repository name should be `SEA-ISS-2025-My-Awesome-Paper`.
 
-    ```{note}
-    For your submissions, please use the following naming convention for your paper repository: `SEA-ISS-2025-<paper-title>`. For example, if your paper title is "My Awesome Paper", your repository name should be `SEA-ISS-2025-My-Awesome-Paper`.
-    ```
 
 3. **Activate GitHub Pages**: Once you created your repository, go to the settings of your repository, scroll down to the "Pages" section, and under "Build and deployment" choose Source: "GitHub Actions". This will allow you to view your Jupyter Book online.
-This will be automatically triggered when you push your changes to your repository. Once you activate this, you can view your Jupyter Book by clicking on the link provided in the "Pages" section of your repository settings. If you have any issues with this step, please reach out to the conference organizers.
+This will be automatically triggered when you push your changes to your repository. Once you activate this, you can view your Jupyter Book by clicking on the link provided in the "Pages" section of your repository settings. If you have any issues with this step, please reach out to the [conference organizers](mailto:iss_proceedings@ucar.edu).
 
 4. **Environment Setup**: Update the `environment.yml` file and add any additional packages you may require. 
 
@@ -30,7 +34,6 @@ This will be automatically triggered when you push your changes to your reposito
     ├── notebook1.ipynb
     └── notebook2.ipynb
     ```
-
 
     This framework supports [the MyST Markdown language](https://jupyterbook.org/en/stable/reference/glossary.html#term-MyST) in Markdown and notebook documents. This allows users to write rich, publication-quality markup in their documents.
 
@@ -48,16 +51,16 @@ This will be automatically triggered when you push your changes to your reposito
 **Citations and Bibliography**: For adding citations to your paper and referencing others, please see our detailed guidelines [here](notebooks/example_2/notebook-example2_references.md). In short, after adding your references to your `references.bib` file, you can add the citation to your paper using the `{cite}[authoryearkey]` syntax.
 ```
 
-If you have any questions or need help with your submission, please reach out to the conference organizers or open an issue in this repository.
+If you have any questions or need help with your submission, please reach out to the [conference organizers](mailto:iss_proceedings@ucar.edu) or open an issue in this repository.
 
 ## Ready to Submit your Paper? 📝
 
-* **Submit your Paper:** Once you've completed the steps above, you can submit your paper to the conference organizers:
+* **Submit your Paper:** Once you've completed the steps above, you can submit your paper to the [conference organizers](mailto:iss_proceedings@ucar.edu):
   * Once you are ready to submit your paper, go to the "Issues" tab of this repository and [click "New Issue"](https://github.com/UCAR-SEA/SEA-ISS-Template/issues/new).
   * Someone from the SEA committee will add your github username to the list of collaborators for the UCAR-SEA github organization.
   * Once you accepted the invitation, you can transfer your repository to the UCAR-SEA organization.
   * Navigate to the settings of your paper repository, scroll down to the Danger Zone, and click "Transfer" . 
-  * Select or type "UCAR-SEA" to transfer the repository to the conference organizers. This step will make your paper public and allow the conference organizers to review your paper.
+  * Select or type "UCAR-SEA" to transfer the repository to the [conference organizers](mailto:iss_proceedings@ucar.edu). This step will make your paper public and allow the [conference organizers](mailto:iss_proceedings@ucar.edu) to review your paper.
 
 
 ### Make Zenodo DOI for your paper
@@ -89,5 +92,5 @@ You can submit your paper as one notebook or split it up to multiple notebooks a
 
 
 ```{note}
-Please reach out to the conference organizers or open an issue or a discussion in this repository if you have any questions or need help with your submission.
+Please reach out to the [conference organizers](mailto:iss_proceedings@ucar.edu) or open an issue or a discussion in this repository if you have any questions or need help with your submission.
 ```

--- a/submission-guidelines.md
+++ b/submission-guidelines.md
@@ -11,7 +11,6 @@
 
 ```{note}
    If you want to learn more about Git and GitHub, you can check out the following tutorials: 
-   - [Git Handbook](https://guides.github.com/introduction/git-handbook/)
    - [Version Control with Git](https://swcarpentry.github.io/git-novice/)
    - [Git Branching Guide](https://learngitbranching.js.org/)
 ```
@@ -85,11 +84,9 @@ If you have any questions or need help with your submission, please reach out to
 
 -----------------
 
-
 ```{tip}
 You can submit your paper as one notebook or split it up to multiple notebooks and markdown files. Please see the [example paper1](notebooks/notebook-template) and [example paper2](notebooks/example_2/notebook-example2_part1) for examples of how to structure your paper.
 ```
-
 
 ```{note}
 Please reach out to the [conference organizers](mailto:iss_proceedings@ucar.edu) or open an issue or a discussion in this repository if you have any questions or need help with your submission.

--- a/submission-guidelines.md
+++ b/submission-guidelines.md
@@ -39,6 +39,7 @@ This will be automatically triggered when you push your changes to your reposito
     [Example paper 1](notebooks/notebook-template) and [Example paper 2](notebooks/example_2/notebook-example2_part1) are provided to help you get started.
     You can either organize all your content in 1 notebook (or markdown file) similar to [this example](notebooks/notebook-template.ipynb) or split it up into multiple notebooks (or markdown files) similar to the [example 2](notebooks/example_2/notebook-example2_part1.md).
 
+
 7. **Update the Table of Contents**: Update the `_toc.yml` file to include the notebooks you've added. Remove the extra examples from the `_toc.yml` file.
 
 8. **Commit your changes**: Commit and push your changes to your repository.
@@ -48,6 +49,10 @@ This will be automatically triggered when you push your changes to your reposito
 
 ```{tip}
 **Citations and Bibliography**: For adding citations to your paper and referencing others, please see our detailed guidelines [here](notebooks/example_2/notebook-example2_references.md). In short, after adding your references to your `references.bib` file, you can add the citation to your paper using the `{cite}[authoryearkey]` syntax.
+```
+
+``` {hint}
+If you are more comfortable using word or latex, you can convert your document to markdown using [pandoc](https://pandoc.org/). To learn more about how to convert your word document to markdown, you can check out [this tutorial](https://bcrf.biochem.wisc.edu/2022/12/30/learn-markdown-episode-6-convert-word-to-markdown-with-pandoc/).
 ```
 
 If you have any questions or need help with your submission, please reach out to the [conference organizers](mailto:iss_proceedings@ucar.edu) or open an issue in this repository.


### PR DESCRIPTION
Here is what has changed:
- [x] This procedure obviously assumes some familiarity with using Git. I would expect that to be common, but for anyone who struggles with git, maybe we should link a beginner tutorial at the start of the How-to (e.g., https://learngitbranching.js.org/)
- [x] The text in #2 under create the paper repository seems to be repeated almost verbatim in the Note box below it. Am I missing something or can one of these be eliminated (probably the note box)?
- [x] At the spots where it says "reach out to the conference organizers" for help, we could have that link to [iss_proceedings@ucar.edu](mailto:iss_proceedings@ucar.edu). 
- [x] Adding a note box about Panddoc