### PR TITLE
Pin to JupyterBook 1

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - python=3.12
-  - jupyter-book
+  - jupyter-book<2
   - jupyterlab
   - jupyterlab-myst
   - sphinx-pythia-theme==2022.3.29


### PR DESCRIPTION
Pins the JupyterBook version to get the build working.  JB2 switches to MyST, which would require some updates on our part.

Once things are in a working state again, I'm planning to archive this repo to avoid any potential confusion (unless there are any concerns about this).



